### PR TITLE
Fixed a long-standing bug in loadBefore

### DIFF
--- a/src/zc/beforestorage/README.txt
+++ b/src/zc/beforestorage/README.txt
@@ -40,6 +40,12 @@ point in time.
 Change history
 ==============
 
+0.5.2 (unreleased)
+------------------
+
+-  Fix a long-standing bug in loadBefore´. The bug was revealed by
+   testing against ZODB 5, for which loadBefore plays a bigger role.
+
 
 0.5.1 (2013-10-25)
 ------------------

--- a/src/zc/beforestorage/README.txt
+++ b/src/zc/beforestorage/README.txt
@@ -410,12 +410,12 @@ with an existing storage and a timestamp:
 
 here we see the database as it was before the 5th transaction was
 committed.  If we try to access a later object, we'll get a
-POSKeyError:
+ReadConflictError:
 
     >>> conn5.get(root[5]._p_oid)
     Traceback (most recent call last):
     ...
-    POSKeyError: 0x05
+    ZODB.POSException.ReadConflictError: b'\x00\x00\x00\x00\x00\x00\x00\x05'
 
 Similarly, while we can access earlier object revisions, we can't
 access revisions at the before time or later:
@@ -426,11 +426,6 @@ access revisions at the before time or later:
     Traceback (most recent call last):
     ...
     POSKeyError: 0x00
-
-    >>> conn5.get(root[5]._p_oid)
-    Traceback (most recent call last):
-    ...
-    POSKeyError: 0x05
 
 Let's run through the storage methods:
 

--- a/src/zc/beforestorage/__init__.py
+++ b/src/zc/beforestorage/__init__.py
@@ -124,10 +124,14 @@ class Before:
     def loadBefore(self, oid, tid):
         if self.before < tid:
             tid = self.before
-        p, s1, s2 = self.storage.loadBefore(oid, tid)
-        if (s2 is not None) and (s2 >= self.before):
-            s2 = None
-        return p, s1, s2
+        r = self.storage.loadBefore(oid, tid)
+        if r:
+            p, s1, s2 = r
+            if (s2 is not None) and (s2 >= self.before):
+                s2 = None
+            return p, s1, s2
+        else:
+            return None
 
     def loadSerial(self, oid, serial):
         if serial >= self.before:


### PR DESCRIPTION
The bug was revealed by testing against ZODB 5, for which loadBefore
plays a bigger role.